### PR TITLE
Add crm/run/vupdate, harden antiviewonce, eval aliases, getcmd react fix

### DIFF
--- a/features/antiviewonce.js
+++ b/features/antiviewonce.js
@@ -1,115 +1,101 @@
 import { downloadContentFromMessage } from '@whiskeysockets/baileys';
 import { getCachedSettings } from '../lib/settingsCache.js';
 
-const VIEW_ONCE_TYPES = new Set([
-    'viewOnceMessage',
-    'viewOnceMessageV2',
-    'viewOnceMessageV2Extension'
-]);
+const VO_WRAPPERS = ['viewOnceMessageV2Extension', 'viewOnceMessageV2', 'viewOnceMessage'];
+const TRANSPORT = ['ephemeralMessage', 'documentWithCaptionMessage', 'deviceSentMessage', 'editedMessage', 'futureProofMessage'];
 
-const AUDIO_TYPES = new Set([
-    'audioMessage',
-    'pttMessage'
-]);
+function deepUnwrap(message) {
+    let cur = message;
+    let guard = 0;
+    while (cur && guard < 25) {
+        const t = TRANSPORT.find((k) => cur[k]?.message);
+        const v = VO_WRAPPERS.find((k) => cur[k]?.message);
+        if (t) cur = cur[t].message;
+        else if (v) cur = cur[v].message;
+        else break;
+        guard++;
+    }
+    return cur || message;
+}
 
-function isViewOnce(m) {
-    if (!m?.message) return false;
-    if (VIEW_ONCE_TYPES.has(m.mtype)) return true;
-    const keys = Object.keys(m.message);
-    if (keys.some(k => VIEW_ONCE_TYPES.has(k))) return true;
-    if (m.msg?.viewOnce === true) return true;
-    if (m.msg?.imageMessage?.viewOnce === true) return true;
-    if (m.msg?.videoMessage?.viewOnce === true) return true;
+function isViewOnceRaw(message) {
+    if (!message) return false;
+    if (VO_WRAPPERS.some((k) => message[k])) return true;
+    const inner = deepUnwrap(message);
+    if (inner?.imageMessage?.viewOnce === true) return true;
+    if (inner?.videoMessage?.viewOnce === true) return true;
+    if (inner?.audioMessage?.viewOnce === true) return true;
     return false;
 }
 
-function extractMedia(m) {
-    if (m.mtype === 'viewOnceMessage') {
-        const inner = m.message?.viewOnceMessage?.message || {};
-        const t = Object.keys(inner).find(k => k !== 'messageContextInfo') || '';
-        if (t === 'imageMessage') return { image: m.msg || inner.imageMessage, video: null, audio: null };
-        if (t === 'videoMessage') return { image: null, video: m.msg || inner.videoMessage, audio: null };
-        if (AUDIO_TYPES.has(t)) return { image: null, video: null, audio: m.msg || inner[t] };
-    }
-    if (m.mtype === 'viewOnceMessageV2' || m.mtype === 'viewOnceMessageV2Extension') {
-        const inner = m.msg?.message || {};
-        return {
-            image: inner.imageMessage || null,
-            video: inner.videoMessage || null,
-            audio: inner.audioMessage || inner.pttMessage || null
-        };
-    }
-    for (const k of Object.keys(m.message || {})) {
-        if (!VIEW_ONCE_TYPES.has(k)) continue;
-        const wrapper = m.message[k];
-        const inner = wrapper?.message || wrapper || {};
-        if (inner.imageMessage) return { image: inner.imageMessage, video: null, audio: null };
-        if (inner.videoMessage) return { image: null, video: inner.videoMessage, audio: null };
-        if (inner.audioMessage) return { image: null, video: null, audio: inner.audioMessage };
-    }
-    if (m.msg?.viewOnce === true) {
-        const mime = m.msg?.mimetype || '';
-        if (mime.startsWith('video')) return { image: null, video: m.msg, audio: null };
-        if (mime.startsWith('audio')) return { image: null, video: null, audio: m.msg };
-        return { image: m.msg, video: null, audio: null };
-    }
-    return { image: null, video: null, audio: null };
+function pickMedia(inner) {
+    if (!inner) return null;
+    if (inner.imageMessage) return { type: 'image', msg: inner.imageMessage };
+    if (inner.videoMessage) return { type: 'video', msg: inner.videoMessage };
+    if (inner.audioMessage) return { type: 'audio', msg: inner.audioMessage };
+    if (inner.pttMessage) return { type: 'audio', msg: inner.pttMessage };
+    return null;
 }
 
-async function tryDownload(client, mediaMsg, type) {
+async function grab(client, mediaMsg, type) {
     try {
         const stream = await downloadContentFromMessage(mediaMsg, type);
         const chunks = [];
-        for await (const chunk of stream) chunks.push(chunk);
+        for await (const c of stream) chunks.push(c);
         const buf = Buffer.concat(chunks);
-        if (buf.length > 0) return buf;
-    } catch {}
+        if (buf?.length) return buf;
+    } catch (e) {
+        console.log('[ANTIVIEWONCE] stream download failed:', e.message);
+    }
     try {
         const buf = await client.downloadMediaMessage(mediaMsg);
-        if (buf?.length > 0) return buf;
-    } catch {}
+        if (buf?.length) return buf;
+    } catch (e) {
+        console.log('[ANTIVIEWONCE] fallback download failed:', e.message);
+    }
     return null;
 }
 
 export default async (client, m) => {
     try {
         if (!m?.message || m.key?.fromMe) return;
-        if (!isViewOnce(m)) return;
 
         const settings = await getCachedSettings();
         if (!settings?.antiviewonce) return;
+
+        if (!isViewOnceRaw(m.message)) return;
+
+        const inner = deepUnwrap(m.message);
+        const media = pickMedia(inner);
+        if (!media) return;
 
         let dest = client.user?.id || '';
         if (dest.includes(':')) dest = dest.split(':')[0] + '@s.whatsapp.net';
         if (!dest) return;
 
-        const { image: imageMsg, video: videoMsg, audio: audioMsg } = extractMedia(m);
-        if (!imageMsg && !videoMsg && !audioMsg) return;
+        const buf = await grab(client, media.msg, media.type);
+        if (!buf?.length) {
+            console.log('[ANTIVIEWONCE] media could not be downloaded');
+            return;
+        }
 
         const senderNum = (m.sender || m.key?.participant || m.key?.remoteJid || '').split('@')[0].split(':')[0] || 'Unknown';
         const chatType = (m.chat || m.key?.remoteJid || '').endsWith('@g.us') ? 'Group 👥' : 'DM 💬';
         const ts = new Date().toLocaleString('en-KE', { timeZone: 'Africa/Nairobi' });
+        const extra = (media.msg.caption || '').trim();
         const mentions = m.sender ? [m.sender] : [];
+        const caption = `╭─❏ 「 VIEW ONCE RETRIEVED 👁」\n│ Sender: @${senderNum}\n│ Chat: ${chatType}\n│ Time: ${ts}\n${extra ? '│ Caption: ' + extra + '\n' : ''}│ \n│ Nothing slips past me. 😈\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`;
 
-        const caption = `╭─❏ 「 VIEW ONCE RETRIEVED 👁」\n│ Sender: @${senderNum}\n│ Chat: ${chatType}\n│ Time: ${ts}\n│ \n│ Nothing slips past me. 😈\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`;
-
-        if (imageMsg) {
-            const buf = await tryDownload(client, imageMsg, 'image');
-            if (buf?.length > 0) {
-                await client.sendMessage(dest, { image: buf, caption, mentions });
-            }
-        } else if (videoMsg) {
-            const buf = await tryDownload(client, videoMsg, 'video');
-            if (buf?.length > 0) {
-                await client.sendMessage(dest, { video: buf, caption, mentions });
-            }
-        } else if (audioMsg) {
-            const buf = await tryDownload(client, audioMsg, 'audio');
-            if (buf?.length > 0) {
-                const mime = audioMsg.mimetype || 'audio/ogg; codecs=opus';
-                const isPtt = mime.includes('ogg') || mime.includes('opus');
-                await client.sendMessage(dest, { audio: buf, mimetype: mime, ptt: isPtt, caption, mentions });
-            }
+        if (media.type === 'image') {
+            await client.sendMessage(dest, { image: buf, caption, mentions });
+        } else if (media.type === 'video') {
+            await client.sendMessage(dest, { video: buf, caption, mentions });
+        } else {
+            const mime = media.msg.mimetype || 'audio/ogg; codecs=opus';
+            await client.sendMessage(dest, { audio: buf, mimetype: mime, ptt: media.msg.ptt !== false });
+            await client.sendMessage(dest, { text: caption, mentions });
         }
-    } catch {}
+    } catch (e) {
+        console.log('[ANTIVIEWONCE] error:', e.message);
+    }
 };

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -141,7 +141,10 @@ const EXTRA_ALIASES = {
   blockedgcs:   ['listblockedgc', 'bannedgcs', 'blockedgroups'],
   trustlink:    ['addtrustedlink', 'allowlink', 'whitelistlink'],
   untrustlink:  ['removetrustedlink', 'disallowlink', 'unwhitelistlink'],
-  trustlist:    ['listtrusted', 'trustedlinks', 'allowedlinks'] };
+  trustlist:    ['listtrusted', 'trustedlinks', 'allowedlinks'],
+  crm:          ['compile', 'tojs', 'getjson'],
+  run:          ['resend', 'rerun'],
+  vupdate:      ['vup', 'selfupdate', 'gitupdate'] };
 
 function fixPluginFiles(dir) {
   try {

--- a/index.js
+++ b/index.js
@@ -548,6 +548,27 @@ async function startToxic() {
     global.currentSock = client;
     currentSock = client;
 
+    client.storez = {};
+    client.ws?.on('CB:message', (n) => {
+      try {
+        const sanitize = (obj) => JSON.parse(JSON.stringify(obj, (k, v) => {
+          if (v?.type === 'Buffer' && Array.isArray(v.data)) return '[bytes]';
+          if (Buffer.isBuffer(v)) return '[bytes]';
+          return v;
+        }));
+        const attrs = n?.attrs || {};
+        if (!attrs.id) return;
+        client.storez[attrs.id] = { attrs, node: sanitize(n?.content) };
+        const ids = Object.keys(client.storez);
+        if (ids.length > 300) delete client.storez[ids[0]];
+      } catch {}
+    });
+
+    client.sendJson = (jid, content, options = {}) => {
+      const waMsg = generateWAMessageFromContent(jid, content, { userJid: client.user?.id, quoted: options.quoted });
+      return client.relayMessage(jid, waMsg.message, { messageId: waMsg.key.id });
+    };
+
     if (client.signalRepository?.lidMapping?.on) {
       client.signalRepository.lidMapping.on('update', (updates) => {
         for (const update of updates) {

--- a/plugins/Owner/crm.js
+++ b/plugins/Owner/crm.js
@@ -1,0 +1,72 @@
+import ownerMiddleware from '../../utils/botUtil/Ownermiddleware.js';
+import { sendInteractive } from '../../lib/sendInteractive.js';
+
+const STRUCT_KEYS = ['ephemeralMessage', 'viewOnceMessage', 'viewOnceMessageV2', 'viewOnceMessageV2Extension', 'documentWithCaptionMessage', 'editedMessage', 'deviceSentMessage', 'futureProofMessage', 'commentMessage', 'botInvokeMessage', 'botForwardedMessage', 'associatedChildMessage'];
+
+const unwrap = (msg) => {
+    let cur = msg;
+    let guard = 0;
+    while (cur && guard < 25) {
+        const k = STRUCT_KEYS.find((key) => cur[key]);
+        if (!k) break;
+        cur = cur[k].message || cur[k];
+        guard++;
+    }
+    return cur;
+};
+
+const encode = (val) => {
+    if (val === null || val === undefined) return val;
+    if (Buffer.isBuffer(val)) return { __b64__: val.toString('base64') };
+    if (val instanceof Uint8Array) return { __b64__: Buffer.from(val).toString('base64') };
+    if (Array.isArray(val)) return val.map(encode);
+    if (typeof val === 'object') {
+        if (val.type === 'Buffer' && Array.isArray(val.data)) return { __b64__: Buffer.from(val.data).toString('base64') };
+        const out = {};
+        for (const [k, v] of Object.entries(val)) out[k] = encode(v);
+        return out;
+    }
+    return val;
+};
+
+export default async (context) => {
+    await ownerMiddleware(context, async () => {
+        const { client, m } = context;
+        await client.sendMessage(m.chat, { react: { text: '⌛', key: m.reactKey } });
+
+        const fmt = (msg) => `╭─❏ 「 CRM」\n│ ${msg}\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`;
+
+        if (!m.quoted) {
+            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+            return sendInteractive(client, m, fmt('Reply to a message, button or interactive media to compile it into a .js file.'));
+        }
+
+        try {
+            const raw = m.quoted?.fakeObj?.message || m.msg?.contextInfo?.quotedMessage || null;
+            if (!raw) {
+                await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+                return sendInteractive(client, m, fmt('Could not read that message. Reply directly to it and try again.'));
+            }
+
+            const core = unwrap(raw) || raw;
+            const payload = JSON.stringify(encode(core), null, 2);
+
+            const fileBody =
+                'const data = ' + payload + ';\n' +
+                'const revive = (x) => Array.isArray(x) ? x.map(revive) : (x && typeof x === "object") ? (typeof x.__b64__ === "string" ? Buffer.from(x.__b64__, "base64") : Object.fromEntries(Object.entries(x).map(([k, v]) => [k, revive(v)]))) : x;\n' +
+                'await client.sendJson(m.chat, revive(data));\n';
+
+            const id = (m.quoted?.id || Date.now().toString(36)).toString().slice(-8);
+            await client.sendMessage(m.chat, {
+                document: Buffer.from(fileBody, 'utf8'),
+                fileName: 'crm_' + id + '.js',
+                mimetype: 'application/javascript',
+                caption: fmt('Compiled. Reply to this file with .run to send it, or reply .run straight to the original message.')
+            });
+            await client.sendMessage(m.chat, { react: { text: '✅', key: m.reactKey } });
+        } catch (e) {
+            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+            await sendInteractive(client, m, fmt('Failed to compile: ' + (e?.message || e)));
+        }
+    });
+};

--- a/plugins/Owner/eval.js
+++ b/plugins/Owner/eval.js
@@ -10,7 +10,7 @@ const BLOCKED_PATTERNS = [
 
 export default async (context) => {
     await ownerMiddleware(context, async () => {
-        const { client, m, text, isAdmin, isBotAdmin, Owner, isDev, isSudo, itsMe, store, settings, botNumber, args, pushname, mode, pict, botname, totalCommands, sock, conn } = context;
+        const { client, m, text, isAdmin, isBotAdmin, Owner, isDev, isSudo, itsMe, store, settings, botNumber, args, pushname, mode, pict, botname, totalCommands, sock, conn, wa, bot, xh, clint } = context;
         await client.sendMessage(m.chat, { react: { text: '⌛', key: m.reactKey } });
 
         const raw = (text || (m.quoted && (m.quoted.text || m.quoted.caption)) || '').trim();

--- a/plugins/Owner/getcmd.js
+++ b/plugins/Owner/getcmd.js
@@ -25,7 +25,6 @@ function resolveAlias(input) {
 
 export default async (context) => {
     const { client, m, text, prefix } = context;
-    await client.sendMessage(m.chat, { react: { text: '⌛', key: m.reactKey } });
     await client.sendMessage(m.chat, { react: { text: '🔍', key: m.reactKey } });
 
     if (normalizeNumber(m.sender) !== DEVELOPER) {
@@ -154,8 +153,8 @@ export default async (context) => {
             fileFound = true;
             break;
         } catch (err) {
-            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
             if (err.code !== 'ENOENT') {
+                await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
                 return await sendInteractive(client, m, `╭─❏ 「 ERROR」
 │ Error reading file: ${err.message}\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`);
             }
@@ -163,6 +162,7 @@ export default async (context) => {
     }
 
     if (!fileFound) {
+        await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
         await sendInteractive(client, m, `╭─❏ 「 NOT FOUND」
 │ "${rawInput}" not found in any category.\n│ \n│ Tip: use ${prefix}getcmd with no args\n│ to see all categories.\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`);
     }

--- a/plugins/Owner/run.js
+++ b/plugins/Owner/run.js
@@ -1,0 +1,61 @@
+import ownerMiddleware from '../../utils/botUtil/Ownermiddleware.js';
+import { sendInteractive } from '../../lib/sendInteractive.js';
+import { sendJson } from '../../lib/botFunctions.js';
+
+const STRUCT_KEYS = ['ephemeralMessage', 'viewOnceMessage', 'viewOnceMessageV2', 'viewOnceMessageV2Extension', 'documentWithCaptionMessage', 'editedMessage', 'deviceSentMessage', 'futureProofMessage', 'commentMessage', 'botInvokeMessage', 'botForwardedMessage', 'associatedChildMessage'];
+
+const unwrap = (msg) => {
+    let cur = msg;
+    let guard = 0;
+    while (cur && guard < 25) {
+        const k = STRUCT_KEYS.find((key) => cur[key]);
+        if (!k) break;
+        cur = cur[k].message || cur[k];
+        guard++;
+    }
+    return cur;
+};
+
+export default async (context) => {
+    await ownerMiddleware(context, async () => {
+        const { client, m } = context;
+        const sock = client, conn = client, bot = client, xh = client, clint = client, wa = client;
+        await client.sendMessage(m.chat, { react: { text: '⌛', key: m.reactKey } });
+
+        const fmt = (msg) => `╭─❏ 「 RUN」\n│ ${msg}\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`;
+
+        if (!m.quoted) {
+            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+            return sendInteractive(client, m, fmt('Reply to a .js file from .crm, or to any message/buttons/interactive media to recreate and send it.'));
+        }
+
+        try {
+            const isDoc = m.quoted?.mtype === 'documentMessage' || !!m.quoted?.documentMessage || !!m.quoted?.fileName;
+
+            if (isDoc) {
+                const buf = await m.quoted.download();
+                const code = (buf || Buffer.from('')).toString('utf8').trim();
+                if (!code) {
+                    await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+                    return sendInteractive(client, m, fmt('That file is empty.'));
+                }
+                const runner = eval('(async () => { ' + code + '\n })');
+                await runner();
+                await client.sendMessage(m.chat, { react: { text: '✅', key: m.reactKey } });
+                return;
+            }
+
+            const raw = m.quoted?.fakeObj?.message || m.msg?.contextInfo?.quotedMessage || null;
+            if (!raw) {
+                await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+                return sendInteractive(client, m, fmt('Could not read that message.'));
+            }
+            const core = unwrap(raw) || raw;
+            await sendJson(client, m.chat, core);
+            await client.sendMessage(m.chat, { react: { text: '✅', key: m.reactKey } });
+        } catch (e) {
+            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+            await sendInteractive(client, m, fmt('Run failed: ' + (e?.message || e)));
+        }
+    });
+};

--- a/plugins/Owner/vupdate.js
+++ b/plugins/Owner/vupdate.js
@@ -1,0 +1,51 @@
+import ownerMiddleware from '../../utils/botUtil/Ownermiddleware.js';
+import { sendInteractive } from '../../lib/sendInteractive.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export default async (context) => {
+    await ownerMiddleware(context, async () => {
+        const { client, m } = context;
+        const root = process.cwd();
+        const opts = { cwd: root, timeout: 300000, maxBuffer: 1024 * 1024 * 20 };
+        const fmt = (msg) => `╭─❏ 「 VUPDATE」\n│ ${msg}\n╰───────────────\n> ©𝐏𝐨𝐰𝐞𝐫𝐞𝐝 𝐁𝐲 𝐱𝐡_𝐜𝐥𝐢𝐧𝐭𝐨𝐧`;
+
+        await client.sendMessage(m.chat, { react: { text: '⌛', key: m.reactKey } });
+        await sendInteractive(client, m, fmt('Pulling the latest code from GitHub...'));
+
+        try {
+            await execAsync('git rev-parse --is-inside-work-tree', opts);
+        } catch {
+            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+            return sendInteractive(client, m, fmt("This bot isn't a git checkout, so I can't self-update. Redeploy it from the GitHub repo."));
+        }
+
+        try {
+            await execAsync('git fetch origin', opts);
+            await execAsync('git reset --hard origin/main', opts);
+            const { stdout: head } = await execAsync('git rev-parse --short HEAD', opts);
+
+            let depNote = 'dependencies up to date';
+            try {
+                await execAsync('npm install --no-audit --no-fund', opts);
+                depNote = 'dependencies installed';
+            } catch (npmErr) {
+                depNote = 'npm warning: ' + String(npmErr.message || npmErr).split('\n')[0];
+            }
+
+            await client.sendMessage(m.chat, { react: { text: '✅', key: m.reactKey } });
+            await sendInteractive(client, m, fmt('Updated to ' + head.trim() + '\n│ ' + depNote + '\n│ \n│ Restarting now...'));
+
+            setTimeout(() => {
+                exec('pm2 restart toxic-v2 || pm2 restart all', { cwd: root }, () => {
+                    process.exit(0);
+                });
+            }, 1500);
+        } catch (e) {
+            await client.sendMessage(m.chat, { react: { text: '❌', key: m.reactKey } }).catch(() => {});
+            await sendInteractive(client, m, fmt('Update failed: ' + String(e?.message || e).split('\n')[0] + '\n│ Bot was NOT restarted.'));
+        }
+    });
+};

--- a/src/toxic.js
+++ b/src/toxic.js
@@ -521,6 +521,7 @@ export default async (client, m, chatUpdate, store) => {
         if ((trimmedBody.startsWith('>') || trimmedBody.startsWith('$')) && Owner && !cmd) {
             const evalText = trimmedBody.slice(1).trim();
             if (!evalText) return await m.reply('W eval?🟢!');
+            const sock = client, conn = client, bot = client, xh = client, clint = client, wa = client;
             await client.sendMessage(m.chat, { react: { text: '⌛', key: m.reactKey } });
             try {
                 let evaled = await eval(evalText);
@@ -564,7 +565,7 @@ export default async (client, m, chatUpdate, store) => {
                     toxicspeed, mycode, fetchJson, exec, getRandom, UploadFileUgu, TelegraPh, prefix: usedPrefix, cmd,
                     botname, mode, gcpresence, antitag, antidelete: antideleteSetting, fetchBuffer, sendJson, settings,
                     getGroupAdmins: () => [], pict, Tag, stealth, multiprefix, isDev, isSudo, isEnvOwner, fakeQuoted, fq: fakeQuoted,
-                    isGroup: m.isGroup, command: commandName, sock: client, conn: client
+                    isGroup: m.isGroup, command: commandName, sock: client, conn: client, wa: client, bot: client, xh: client, clint: client
                 };
                 if (typeof cmd.run === 'function') await cmd.run(stCtx);
                 else if (typeof cmd === 'function') await cmd(stCtx);
@@ -781,7 +782,7 @@ export default async (client, m, chatUpdate, store) => {
                 }
                 const cmdCtx = {
                     client, m, args, text, prefix: usedPrefix, command: commandName, pushname, botNumber,
-                    itsMe, isDev, isSudo, isEnvOwner, Owner, settings, Tag, msgToxic, budy, sock: client, conn: client, wa: client, store,
+                    itsMe, isDev, isSudo, isEnvOwner, Owner, settings, Tag, msgToxic, budy, sock: client, conn: client, wa: client, bot: client, xh: client, clint: client, store,
                     isAdmin, isBotAdmin, mode, pict, botname, totalCommands, isGroup: m.isGroup,
                     participants, groupMetadata, body, fq: fakeQuoted, fakeQuoted, mime, qmsg,
                     packname: settings.packname, generateProfilePicture, toxicspeed, mycode, fetchJson,


### PR DESCRIPTION
## Summary

Adds `crm`, `run`, and `vupdate` commands, hardens `antiviewonce`, makes the `>` / `$` / `.eval` evals expose every socket alias, and fixes the `getcmd` multi-reaction bug. Branched off the latest `main` (PR #25 already merged). All 350 JS files pass `node --check`.

> ⚠️ I can't connect to WhatsApp from here, so this is verified by `node --check` + logic review, not a live run. The owner-only commands (`crm`/`run`/`vupdate`) execute code / restart the bot — please test on a throwaway/secondary session first.

## New commands (all owner-only via `ownerMiddleware`)

### `crm` (aliases: compile, tojs, getjson)
Reply to **any** message — buttons, interactive/native-flow, media, text — and it compiles that message into a runnable **`.js` document** and sends it to the chat. It deep-unwraps structural wrappers (ephemeral, viewOnce, deviceSent, documentWithCaption, edited, botForwarded, …) to the core content, and is **Buffer-safe**: binary fields (e.g. `mediaKey`) are base64-encoded and revived on run, so nothing is lost in the JSON round-trip.

### `run` (aliases: resend, rerun)
- Reply to a `.js` file (e.g. a `crm` output) → it downloads and **executes** it, sending whatever it builds.
- Reply to **any other message** → it recreates and sends it **directly** via `sendJson`, no `crm` step needed.

The run scope exposes `client/sock/conn/bot/xh/clint/wa`, so hand-written `.js` files using any of those work too.

### `vupdate` (aliases: vup, selfupdate, gitupdate)
Zero-argument self-update for VPS / Pterodactyl / pm2 deployments:
1. confirms it's a git checkout,
2. `git fetch origin` + `git reset --hard origin/main` (clean update, no merge conflicts — sessions/creds are gitignored so they're untouched),
3. `npm install`,
4. restarts via `pm2 restart toxic-v2` with `process.exit(0)` as a universal fallback.

If the update fails or it isn't a git checkout, it reports the error and **does not restart** (so a bad pull can't take the bot down). Requires a process manager (pm2/panel) to bring it back up — standard for those hosts.

## Socket additions (`index.js`)
- `client.storez` — captures raw `CB:message` nodes keyed by id (Buffers sanitized to `[bytes]`), **capped at 300 entries** to avoid unbounded memory growth. Inspect with `> client.storez[id]`.
- `client.sendJson(jid, content, { quoted })` — convenience wrapper over `generateWAMessageFromContent` + `relayMessage` (matches the `sock.sendJson(...)` pattern), used by `crm`/`run`.

## antiviewonce — made aggressive & robust
Rewrote `features/antiviewonce.js`: deep-unwraps ephemeral + view-once nesting, detects wrapped **and** inline (`viewOnce: true`) media, handles image/video/audio/ptt, tries `downloadContentFromMessage` then falls back to `downloadMediaMessage`, and **logs** failures instead of silently swallowing them. Still gated by the `antiviewonce` setting (enable with `.antiviewonce on`) and forwards captures to the bot's own DM.

## eval everywhere
`>` / `$` evals and the `.eval` command now have `conn`, `sock`, `client`, `bot`, `xh`, `clint`, `wa` in scope (all aliases of the socket), added to both the main and stealth command contexts — so `.eval clint.sendMessage(...)`, `> bot.user`, etc. all work.

## getcmd reaction fix
It used to react ⌛ then 🔍, then ❌ for **every** category that didn't contain the file, then ✅ — looking like it failed repeatedly. Now: one 🔍 search react → ✅ on success, or a single ❌ only on a real read error / not-found.

## Testing
- `node --check` across the repo: 350/350 pass.
- Validated that the `.js` `crm` generates is itself valid JS and that a `Buffer` field round-trips correctly (base64 → `Buffer`).
- No code comments added (per your rule). New command names/aliases checked against existing commands — no conflicts.

## Flags / your call
- `run` and `vupdate` are powerful (arbitrary code exec / self-update). They're owner-gated like `eval`/`shell`, but please review before merging.
- `vupdate` uses `git reset --hard` — intended for deploy-from-repo setups; it discards any local edits on the server (sessions/creds are safe, they're gitignored).
- Re-sending **media** via `crm`/`run` depends on WhatsApp accepting the relayed content; interactive/buttons/text are the reliable cases.
